### PR TITLE
DEV: Promote unsafe CSP check to ProblemCheck (#308)

### DIFF
--- a/app/services/problem_check/unsafe_csp.rb
+++ b/app/services/problem_check/unsafe_csp.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class ProblemCheck::UnsafeCsp < ProblemCheck
+  self.priority = "low"
+
+  def call
+    return no_problem if !SiteSetting.encrypt_enabled?
+    return no_problem if !SiteSetting.content_security_policy?
+    return no_problem if safe_policy?
+
+    problem
+  end
+
+  private
+
+  def safe_policy?
+    DiscourseEncrypt.safe_csp_src?(SiteSetting.content_security_policy_script_src)
+  end
+
+  def translation_key
+    "site_settings.errors.encrypt_unsafe_csp"
+  end
+end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -12,4 +12,4 @@ en:
     encrypt_pms_default: "Encrypt all new private messages by default."
 
     errors:
-      encrypt_unsafe_csp: "Unsafe CSP directives like 'unsafe-eval' and 'unsafe-inline' cannot be used when the Discourse Encrypt plugin is enabled. "
+      encrypt_unsafe_csp: "Unsafe CSP directives like 'unsafe-eval' and 'unsafe-inline' cannot be used when the Discourse Encrypt plugin is enabled."

--- a/plugin.rb
+++ b/plugin.rb
@@ -49,6 +49,7 @@ after_initialize do
   require_relative "app/models/encrypted_topics_data.rb"
   require_relative "app/models/encrypted_topics_user.rb"
   require_relative "app/models/user_encryption_key.rb"
+  require_relative "app/services/problem_check/unsafe_csp.rb"
   require_relative "lib/email_sender_extensions.rb"
   require_relative "lib/encrypted_post_creator.rb"
   require_relative "lib/encrypted_search.rb"
@@ -114,14 +115,6 @@ after_initialize do
   register_search_topic_eager_load do |opts|
     if SiteSetting.encrypt_enabled? && opts[:search_pms]
       %i[encrypted_topics_users encrypted_topics_data]
-    end
-  end
-
-  AdminDashboardData.add_problem_check do
-    if SiteSetting.content_security_policy? &&
-         !DiscourseEncrypt.safe_csp_src?(SiteSetting.content_security_policy_script_src) &&
-         SiteSetting.encrypt_enabled?
-      I18n.t("site_settings.errors.encrypt_unsafe_csp")
     end
   end
 

--- a/spec/services/problem_check/unsafe_csp_spec.rb
+++ b/spec/services/problem_check/unsafe_csp_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe ProblemCheck::UnsafeCsp do
+  let(:check) { described_class.new }
+
+  context "when encryption is not enabled" do
+    before { SiteSetting.stubs(encrypt_enabled?: false) }
+
+    it { expect(check).to be_chill_about_it }
+  end
+
+  context "when no CSP is configured" do
+    before { SiteSetting.stubs(content_security_policy?: false) }
+
+    it { expect(check).to be_chill_about_it }
+  end
+
+  context "when using a safe CSP configuration" do
+    before do
+      SiteSetting.stubs(encrypt_enabled?: true)
+      SiteSetting.stubs(content_security_policy?: true)
+      SiteSetting.stubs(content_security_policy_script_src: "script-src")
+    end
+
+    it { expect(check).to be_chill_about_it }
+  end
+
+  context "when using an unsafe CSP configuration" do
+    before do
+      SiteSetting.stubs(encrypt_enabled?: true)
+      SiteSetting.stubs(content_security_policy?: true)
+      SiteSetting.stubs(content_security_policy_script_src: "script-src 'unsafe-inline'")
+    end
+
+    it do
+      expect(check).to have_a_problem.with_priority("low").with_message(
+        "Unsafe CSP directives like 'unsafe-eval' and 'unsafe-inline' cannot be used when the Discourse Encrypt plugin is enabled.",
+      )
+    end
+  end
+end


### PR DESCRIPTION
We're promoting problem checks to first class citizens in core. This migrates the problem check to the new API.