### PR TITLE
DEV: Explicitly register problem check (#310)

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -112,6 +112,8 @@ after_initialize do
     UserNotificationRenderer.singleton_class.prepend DiscourseEncrypt::UserNotificationRendererExtensions
   end
 
+  register_problem_check ProblemCheck::UnsafeCsp
+
   register_search_topic_eager_load do |opts|
     if SiteSetting.encrypt_enabled? && opts[:search_pms]
       %i[encrypted_topics_users encrypted_topics_data]


### PR DESCRIPTION
In discourse/discourse#26413 we are changing problem checks to require explicit registration. As part of that we're adding a filtered register to the plugin registry. This PR makes use of that new register.